### PR TITLE
added cross-env for for windows dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"autoprefixer": "^10.4.19",
+				"cross-env": "^7.0.3",
 				"postcss": "^8.4.38",
 				"svelte": "^4.2.18",
 				"svelte-check": "^3.6.0",
@@ -1864,6 +1865,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
 			}
 		},
 		"node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "NODE_ENV=development vite",
+		"dev": "cross-env NODE_ENV=development vite",
 		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -14,6 +14,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"autoprefixer": "^10.4.19",
+		"cross-env": "^7.0.3",
 		"postcss": "^8.4.38",
 		"svelte": "^4.2.18",
 		"svelte-check": "^3.6.0",


### PR DESCRIPTION
"NODE_EVN=development vite" would not run. using "cross-env NODE_ENV=development vite" requires installing cross-env with `npm install cross-env --save-dev
` but allows dev on other platforms